### PR TITLE
fixing bug when id is string "all"

### DIFF
--- a/src/features/Gw2/actions.js
+++ b/src/features/Gw2/actions.js
@@ -66,7 +66,7 @@ export function generateActions (resourceName, getResource, afterGet) {
       // We filter them, then pass them along to the service (for example lib/gw2/readCalculatedItemStats)
       // If calculatedId exists, use that.
       const actualId = +(typeof id === 'object' ? (id.calculatedId || id.id) : id);
-      const isValidId = actualId && actualId !== -1;
+      const isValidId = (id === 'all') || (actualId && actualId !== -1);
       const isNotInStore = !store[resourceName][actualId] || !!store[resourceName][actualId].error;
       return isValidId && isNotInStore;
     }));

--- a/src/features/Gw2/actions.spec.js
+++ b/src/features/Gw2/actions.spec.js
@@ -99,6 +99,32 @@ describe('gw2 action factory', () => {
       return action(dispatch, getStore);
     });
 
+    describe('when id is string', () => {
+      it('should dispatch when id is "all"', () => {
+        // Arrange
+        const ids = ['all'];
+        const action = actions.fetchAmulets(ids);
+
+        // Act
+        action(dispatch, getStore);
+
+        // Assert
+        expect(getFunc.firstCall.args[0]).to.eql(ids);
+      });
+
+      it ('should error if any other string', () => {
+        // Arrange
+        const ids = ['balthazar'];
+        const action = actions.fetchAmulets(ids);
+
+        // Act
+        action(dispatch, getStore);
+
+        // Assert
+        expect(getFunc).to.not.have.been.called;
+      });
+    });
+
     describe('when ids are actually complex objects', () => {
       it('should call service with them', () => {
         const ids = [{ id: 5 }, { id: 6 }];

--- a/src/features/Gw2/actions.spec.js
+++ b/src/features/Gw2/actions.spec.js
@@ -112,7 +112,7 @@ describe('gw2 action factory', () => {
         expect(getFunc.firstCall.args[0]).to.eql(ids);
       });
 
-      it ('should error if any other string', () => {
+      it('should error if any other string', () => {
         // Arrange
         const ids = ['balthazar'];
         const action = actions.fetchAmulets(ids);


### PR DESCRIPTION
When certain fetch calls are made with id = ['all'], the id validation previously failed because 'all' is neither an object or an integer. ActualId would be set to NaN and the filter function would return false.